### PR TITLE
CI: Initial packaging implementation

### DIFF
--- a/.github/workflows/package.Dockerfile
+++ b/.github/workflows/package.Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:latest AS builder
+
+RUN apk add alpine-sdk ccache doas git
+RUN adduser -D abuild-user
+RUN addgroup abuild-user abuild
+RUN echo "permit nopass abuild-user" >> /etc/doas.conf
+USER abuild-user
+RUN USER=rd-openresty abuild-keygen --append --install -n
+RUN mkdir -p ~/.abuild
+RUN echo "JOBS=`nproc`" >> ~/.abuild/abuild.conf
+
+ADD --chown=abuild-user alpine /alpine/
+RUN git clone -b v0.0.3 https://github.com/chobits/ngx_http_proxy_connect_module /alpine/ngx_http_proxy_connect_module
+
+WORKDIR /alpine/openresty-zlib
+RUN abuild -r
+WORKDIR /alpine/openresty-pcre
+RUN abuild -r
+WORKDIR /alpine/openresty-openssl111
+RUN abuild -r
+WORKDIR /alpine/openresty
+RUN abuild -r
+
+WORKDIR /home/abuild-user/packages/alpine/
+RUN cp ~/.abuild/rd-openresty-*.pub .
+RUN tar cvf /tmp/openresty.tar \
+    *.pub \
+    $(uname -m)/rd-openresty-[0-9]*.apk \
+    $(uname -m)/rd-openresty-openssl111-[0-9]*.apk \
+    $(uname -m)/rd-openresty-pcre-[0-9]*.apk \
+    $(uname -m)/rd-openresty-zlib-[0-9]*.apk
+
+FROM scratch
+ARG TARGETARCH
+COPY --from=builder /tmp/openresty.tar /openresty-${TARGETARCH}.tar

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,30 @@
+name: Package OpenResty
+on:
+  workflow_dispatch: {}
+permissions: {}
+jobs:
+  package:
+    strategy:
+      matrix:
+        include:
+        - arch: amd64
+        - arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ matrix.arch }}
+    - uses: docker/setup-buildx-action@v3
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - run: >-
+        docker buildx build
+        --platform=linux/${{ matrix.arch }}
+        --output=type=local,dest=.
+        --file=.github/workflows/package.Dockerfile .
+    - uses: actions/upload-artifact@v4
+      with:
+        name: openresty-${{ matrix.arch }}.tar
+        path: openresty-${{ matrix.arch }}.tar
+        if-no-files-found: error

--- a/alpine/openresty/APKBUILD
+++ b/alpine/openresty/APKBUILD
@@ -67,7 +67,7 @@ build() {
         --with-threads \
         --with-compat \
         --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
-        --add-module=/home/jan.linux/ngx_http_proxy_connect_module \
+        --add-module=../../../ngx_http_proxy_connect_module \
         -j$JOBS
 
     make -j$JOBS


### PR DESCRIPTION
This lets us build openresty packages for use in Rancher Desktop in CI, so that it is more reproducible (and so that any member of the team may trigger a build).

Note that this currently just manually triggered, instead of doing it on a release; we'll need to make it do it on release later, but I wanted to get the initial PR up first.

Sample run: https://github.com/mook-as/rd-openresty-packaging/actions/runs/9505001895