### PR TITLE
CI: Add workflow to create release on tagging

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,23 @@
 name: Package OpenResty
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      alpine-version:
+        description: Alpine Linux release version to build for
+        default: '3.20'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      alpine-version:
+        description: Alpine Linux release version to build for
+        default: '3.20'
+        required: false
+        type: string
+      release-version:
+        description: Rancher Desktop OpenResty release tag
+        required: false
+        type: string
 permissions: {}
 jobs:
   package:
@@ -22,9 +39,12 @@ jobs:
         docker buildx build
         --platform=linux/${{ matrix.arch }}
         --output=type=local,dest=.
-        --file=.github/workflows/package.Dockerfile .
+        --file=.github/workflows/package.Dockerfile
+        --build-arg=RELEASE_VERSION=${{ inputs.release-version }}
+        --build-arg=ALPINE_VERSION=${{ inputs.alpine-version }}
+        .
     - uses: actions/upload-artifact@v4
       with:
         name: openresty-${{ matrix.arch }}.tar
-        path: openresty-${{ matrix.arch }}.tar
+        path: openresty-*.tar
         if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release OpenResty
+on: { push: { tags: [ '*' ] } }
+permissions: {}
+jobs:
+  package:
+    uses: ./.github/workflows/package.yaml
+    with:
+      release-version: ${{ github.ref_name }}
+  release:
+    needs: package
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+    - name: Create release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ref: ${{ github.ref_name }}
+      run: >-
+        gh release create
+        "$ref"
+        openresty-*.tar/*.tar
+        --draft
+        --title "${ref#test-}"
+        --repo "${{ github.repository }}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 *.build
 *.buildinfo
 *.changes
+
+/openresty-*.tar


### PR DESCRIPTION
The workflow matches some of our other repos:

1. The user pushes a tag to the repository.
2. Automation creates a draft release, populated with binaries.
3. The user publishes the release after testing.

Sample CI run: https://github.com/mook-as/rd-openresty-packaging/actions/runs/9520188230
Sample release (I published it because I wasn't sure draft releases are visible): https://github.com/mook-as/rd-openresty-packaging/releases/tag/v0.0.4
CI triggered manually (not as part of a release): https://github.com/mook-as/rd-openresty-packaging/actions/runs/9520193409

Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/7005