### PR TITLE
Building for openSUSE

### DIFF
--- a/.github/workflows/package-opensuse.Dockerfile
+++ b/.github/workflows/package-opensuse.Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+FROM registry.opensuse.org/opensuse/leap:15 AS builder
+
+RUN zypper --non-interactive install \
+    ccache \
+    libtool \
+    pattern:devel_rpm_build \
+    perl-File-Temp \
+    systemtap-sdt-devel \
+    wget
+# Docker ADD/COPY doesn't derefence symlinks, so we have to copy the whole thing.
+COPY . /src
+RUN rmdir /usr/src/packages/SOURCES /usr/src/packages/SPECS
+RUN ln -s /src/rpm/SOURCES /usr/src/packages/SOURCES
+RUN ln -s /src/rpm/SPECS /usr/src/packages/SPECS
+WORKDIR /usr/src/packages/SOURCES/
+RUN \
+    for file in openresty-zlib openresty-pcre openresty-openssl111 openresty; do \
+    rpmspec -P /usr/src/packages/SPECS/${file}.spec \
+    | awk '/^Source[0-9]+.*http/ { print $2 }' \
+    | xargs wget \
+    ; done
+RUN mv v0.0.3.tar.gz ngx_http_proxy_connect_module-0.0.3.tar.gz
+WORKDIR /usr/src/packages/SPECS/
+RUN rpmbuild -ba openresty-zlib.spec
+RUN rpm --install --nosignature \
+    /usr/src/packages/RPMS/$(uname -m)/rd-openresty-zlib{,-devel}-[0-9]*.$(uname -m).rpm
+RUN rpmbuild -ba openresty-pcre.spec
+RUN rpmbuild -ba openresty-openssl111.spec
+RUN rpm --install --nosignature \
+    /usr/src/packages/RPMS/$(uname -m)/rd-openresty-openssl111{,-devel}-[0-9]*.$(uname -m).rpm \
+    /usr/src/packages/RPMS/$(uname -m)/rd-openresty-pcre{,-devel}-[0-9]*.$(uname -m).rpm
+RUN rpmbuild -ba openresty.spec
+
+FROM scratch
+COPY --from=builder /usr/src/packages/RPMS /RPMS/
+COPY --from=builder /usr/src/packages/SRPMS /SRPMS/

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -48,3 +48,48 @@ jobs:
         name: openresty-${{ matrix.arch }}.tar
         path: openresty-*.tar
         if-no-files-found: error
+  package-opensuse:
+    strategy:
+      matrix:
+        include:
+        - arch: amd64
+        - arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ matrix.arch }}
+    - uses: docker/setup-buildx-action@v3
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - run: >-
+        docker buildx build
+        --platform=linux/${{ matrix.arch }}
+        --output=type=local,dest=.
+        --file=.github/workflows/package-opensuse.Dockerfile
+        .
+    - run: ls -laR 
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rpms-${{ matrix.arch }}
+        path: |
+          RPMS/
+          SRPMS/
+        if-no-files-found: error
+  render-opensuse:
+    needs: package-opensuse
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    steps:
+    - run: sudo DEBIAN_FRONTEND=noninteractive apt-get install createrepo-c
+    - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+    - run: createrepo_c --no-database .
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: .
+    - uses: actions/deploy-pages@v4

--- a/rpm/SOURCES/openssl-1.1.1f-sess_set_get_cb_yield.patch
+++ b/rpm/SOURCES/openssl-1.1.1f-sess_set_get_cb_yield.patch
@@ -1,0 +1,1 @@
+../../alpine/openresty-openssl111/openssl-1.1.1f-sess_set_get_cb_yield.patch

--- a/rpm/SOURCES/proxy_connect_rewrite_102101.patch
+++ b/rpm/SOURCES/proxy_connect_rewrite_102101.patch
@@ -1,0 +1,1 @@
+../../alpine/openresty/proxy_connect_rewrite_102101.patch

--- a/rpm/SPECS/openresty-openssl111.spec
+++ b/rpm/SPECS/openresty-openssl111.spec
@@ -1,4 +1,4 @@
-Name:               openresty-openssl111
+Name:               rd-openresty-openssl111
 Version:            1.1.1s
 Release:            1%{?dist}
 Summary:            OpenSSL library for OpenResty
@@ -17,8 +17,8 @@ Patch0:             https://raw.githubusercontent.com/openresty/openresty/master
 BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:      gcc, make, perl
-BuildRequires:      openresty-zlib-devel >= 1.2.11
-Requires:           openresty-zlib >= 1.2.11
+BuildRequires:      rd-openresty-zlib-devel >= 1.2.11
+Requires:           rd-openresty-zlib >= 1.2.11
 
 AutoReqProv:        no
 

--- a/rpm/SPECS/openresty-pcre.spec
+++ b/rpm/SPECS/openresty-pcre.spec
@@ -1,4 +1,4 @@
-Name:               openresty-pcre
+Name:               rd-openresty-pcre
 Version:            8.45
 Release:            1%{?dist}
 Summary:            Perl-compatible regular expression library for OpenResty

--- a/rpm/SPECS/openresty-zlib.spec
+++ b/rpm/SPECS/openresty-zlib.spec
@@ -1,4 +1,4 @@
-Name:               openresty-zlib
+Name:               rd-openresty-zlib
 Version:            1.2.12
 Release:            1%{?dist}
 Summary:            The zlib compression library for OpenResty
@@ -8,9 +8,9 @@ Group:              System Environment/Libraries
 # /contrib/dotzlib/ have Boost license
 License:            zlib and Boost
 URL:                https://www.zlib.net/
-Source0:            https://www.zlib.net/zlib-%{version}.tar.xz
+Source0:            https://www.zlib.net/fossils/zlib-%{version}.tar.gz
 
-BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}
 
 BuildRequires:      libtool
 


### PR DESCRIPTION
This adds packaging for openSUSE.

Note that this requires GitHub Pages to be enabled for the repository (and set to be deployed from GitHub Actions).

Afterwards, the Pages site (i.e. `https://rancher-sandbox.github.io/openresty-packaging`) will be a valid YUM-style repository that can be added to zypper.