### PR TITLE
CI: Release: Enable permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on: { push: { tags: [ '*' ] } }
 permissions: {}
 jobs:
   package:
+    permissions:
+      id-token: write # Needed for render-opensuse
+      pages: write # Needed for render-opensuse
     uses: ./.github/workflows/package.yaml
     with:
       release-version: ${{ github.ref_name }}


### PR DESCRIPTION
The packaging workflow now requires `id-token` and `pages` permissions to update GitHub Pages for the RPM repository.

Starting this as a draft for CI to check if things are working; see https://github.com/mook-as/rd-openresty-packaging/actions/runs/14344913397