### PR TITLE
CI: Try arm native runners

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -25,8 +25,10 @@ jobs:
       matrix:
         include:
         - arch: amd64
+          runs-on: ubuntu-latest
         - arch: arm64
-    runs-on: ubuntu-latest
+          runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: docker/setup-qemu-action@v3
       with:
@@ -53,8 +55,10 @@ jobs:
       matrix:
         include:
         - arch: amd64
+          runs-on: ubuntu-latest
         - arch: arm64
-    runs-on: ubuntu-latest
+          runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: docker/setup-qemu-action@v3
       with:


### PR DESCRIPTION
Since GitHub-hosted runners have arm64 are in public preview, see if they work for us.

Passing CI run: https://github.com/mook-as/rd-openresty-packaging/actions/runs/14344676027/job/40212198061